### PR TITLE
upgrade toolchain to 1.26.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dhth/kplay
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/atotto/clipboard v0.1.4

--- a/internal/serde/protobuf.go
+++ b/internal/serde/protobuf.go
@@ -198,7 +198,7 @@ func cEscape(data []byte) string {
 				result.WriteByte(b)
 			} else {
 				// Non-printable character - use octal escape
-				result.WriteString(fmt.Sprintf("\\%03o", b))
+				fmt.Fprintf(&result, "\\%03o", b)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- upgrade the Go toolchain from 1.26.1 to 1.26.2
- replace WriteString(fmt.Sprintf(...)) with fmt.Fprintf to satisfy staticcheck on the newer toolchain/lint path